### PR TITLE
fix: changed parameter#2 in http_build_query() call from null to empty string

### DIFF
--- a/src/AbstractService.php
+++ b/src/AbstractService.php
@@ -30,7 +30,7 @@ abstract class AbstractService
         $uri = "$this->service/$this->version/$this->profile/$this->coordinates.$this->format";
         if ($this->options)
         {
-            $uri .= "?" . http_build_query($this->options, null, '&');
+            $uri .= "?" . http_build_query($this->options, "", '&');
         }
 
         return $uri;


### PR DESCRIPTION
hello, great work, I found a little bug in building options into request URI  due to the call of http_build_query with argument #2 set to null instead of empty string, at least in PHP 8.1
thanks & bye
vuk